### PR TITLE
implement clean yaxis datapoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.15
 require (
 	github.com/google/go-cmp v0.5.2
 	github.com/spf13/cobra v1.1.1
-	github.com/venturemark/apigengo v0.0.0-20201113212000-286cd81fb79f
+	github.com/venturemark/apigengo v0.0.0-20201113231625-ccfc7cd43d76
 	github.com/xh3b4sd/logger v0.1.2
-	github.com/xh3b4sd/redigo v0.0.0-20201112202157-36d7e299f1b5
+	github.com/xh3b4sd/redigo v0.0.0-20201113235014-ef17942e8efb
 	github.com/xh3b4sd/tracer v0.3.1
 	google.golang.org/grpc v1.33.2
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/venturemark/apigengo v0.0.0-20201113231625-ccfc7cd43d76
 	github.com/xh3b4sd/logger v0.1.2
-	github.com/xh3b4sd/redigo v0.0.0-20201113235014-ef17942e8efb
+	github.com/xh3b4sd/redigo v0.1.0
 	github.com/xh3b4sd/tracer v0.3.1
 	google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/venturemark/apigengo v0.0.0-20201113231625-ccfc7cd43d76 h1:UgIxN8NJQC
 github.com/venturemark/apigengo v0.0.0-20201113231625-ccfc7cd43d76/go.mod h1:1H03FtN0jnnENa+gdfCRwOTrJVG6c8ztI4EWHRGpD4A=
 github.com/xh3b4sd/logger v0.1.2 h1:zEE3obzyrGofvTNbT+T2U654e9XwqmGbzyktdRB1BR8=
 github.com/xh3b4sd/logger v0.1.2/go.mod h1:/mTz2elyBeH3rPq5vEqAJRWYt/6huhY/b3Hrzych2GE=
-github.com/xh3b4sd/redigo v0.0.0-20201113235014-ef17942e8efb h1:rQmHcWVwNWuA3zrkST6cbevvV5caWNYXmNihST2gwys=
-github.com/xh3b4sd/redigo v0.0.0-20201113235014-ef17942e8efb/go.mod h1:BILWOYa0jGb1rACFyBQCKdoj9LAkSErq8xyi7sDiaMk=
+github.com/xh3b4sd/redigo v0.1.0 h1:HrvUTKfivYq0FL7iVWlEo9biJ/c6sz30YDeGDWWqt7A=
+github.com/xh3b4sd/redigo v0.1.0/go.mod h1:BILWOYa0jGb1rACFyBQCKdoj9LAkSErq8xyi7sDiaMk=
 github.com/xh3b4sd/tracer v0.3.1 h1:wv4Cy/u/xLXLUJeKQWeiR+aU4mywj2f8PkQVda1EXKQ=
 github.com/xh3b4sd/tracer v0.3.1/go.mod h1:ZOLvBVLrmNx3GLCL7j0vEGMuI3r5ltLFcmDjG/3nV7g=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/go.sum
+++ b/go.sum
@@ -193,12 +193,12 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/venturemark/apigengo v0.0.0-20201113212000-286cd81fb79f h1:9bGtagfO6fSuXbRisE/Xa3tSp5ozv3cF42Q8/53ibEI=
-github.com/venturemark/apigengo v0.0.0-20201113212000-286cd81fb79f/go.mod h1:1H03FtN0jnnENa+gdfCRwOTrJVG6c8ztI4EWHRGpD4A=
+github.com/venturemark/apigengo v0.0.0-20201113231625-ccfc7cd43d76 h1:UgIxN8NJQCBIu976GzY081kFpte55MHUBiG7cjsn288=
+github.com/venturemark/apigengo v0.0.0-20201113231625-ccfc7cd43d76/go.mod h1:1H03FtN0jnnENa+gdfCRwOTrJVG6c8ztI4EWHRGpD4A=
 github.com/xh3b4sd/logger v0.1.2 h1:zEE3obzyrGofvTNbT+T2U654e9XwqmGbzyktdRB1BR8=
 github.com/xh3b4sd/logger v0.1.2/go.mod h1:/mTz2elyBeH3rPq5vEqAJRWYt/6huhY/b3Hrzych2GE=
-github.com/xh3b4sd/redigo v0.0.0-20201112202157-36d7e299f1b5 h1:Hat2sO0sORRJKhTRqIaW3CPJwEy/DnhG53BwmjbQUL0=
-github.com/xh3b4sd/redigo v0.0.0-20201112202157-36d7e299f1b5/go.mod h1:BILWOYa0jGb1rACFyBQCKdoj9LAkSErq8xyi7sDiaMk=
+github.com/xh3b4sd/redigo v0.0.0-20201113235014-ef17942e8efb h1:rQmHcWVwNWuA3zrkST6cbevvV5caWNYXmNihST2gwys=
+github.com/xh3b4sd/redigo v0.0.0-20201113235014-ef17942e8efb/go.mod h1:BILWOYa0jGb1rACFyBQCKdoj9LAkSErq8xyi7sDiaMk=
 github.com/xh3b4sd/tracer v0.3.1 h1:wv4Cy/u/xLXLUJeKQWeiR+aU4mywj2f8PkQVda1EXKQ=
 github.com/xh3b4sd/tracer v0.3.1/go.mod h1:ZOLvBVLrmNx3GLCL7j0vEGMuI3r5ltLFcmDjG/3nV7g=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/storage/metupd/create/non/timeline/verify.go
+++ b/pkg/storage/metupd/create/non/timeline/verify.go
@@ -6,9 +6,9 @@ import (
 
 func (t *Timeline) Verify(obj *metupd.CreateI) bool {
 	{
-		// Creating metric updates requires two datapoints. If the client
-		// does not provide that we fail.
-		if len(obj.Datapoint) != 2 {
+		// Creating metric updates requires at least one coordinate on the y
+		// axis. If the client does not provide that we fail.
+		if len(obj.Yaxis) == 0 {
 			return false
 		}
 	}

--- a/pkg/storage/metupd/create/non/timeline/verify_test.go
+++ b/pkg/storage/metupd/create/non/timeline/verify_test.go
@@ -19,45 +19,21 @@ func Test_Timeline_Verify_Invalid(t *testing.T) {
 		{
 			obj: &metupd.CreateI{},
 		},
-		// Case 1 ensures that create input with only a single datapoint is not
-		// valid.
+		// Case 1 ensures that create input without text is not valid.
 		{
 			obj: &metupd.CreateI{
-				Datapoint: []int64{
-					1604959525,
-				},
-				Text:     "Lorem ipsum ...",
-				Timeline: "tml-al9qy",
-			},
-		},
-		// Case 2 ensures that create input with too many datapoints is not
-		// valid.
-		{
-			obj: &metupd.CreateI{
-				Datapoint: []int64{
-					1604959525,
-					85,
-					2387,
-				},
-				Text:     "Lorem ipsum ...",
-				Timeline: "tml-al9qy",
-			},
-		},
-		// Case 3 ensures that create input without text is not valid.
-		{
-			obj: &metupd.CreateI{
-				Datapoint: []int64{
-					1604959525,
+				Yaxis: []int64{
+					32,
 					85,
 				},
 				Timeline: "tml-al9qy",
 			},
 		},
-		// Case 4 ensures that create input without timeline is not valid.
+		// Case 2 ensures that create input without timeline is not valid.
 		{
 			obj: &metupd.CreateI{
-				Datapoint: []int64{
-					1604959525,
+				Yaxis: []int64{
+					32,
 					85,
 				},
 				Text: "Lorem ipsum ...",
@@ -95,22 +71,35 @@ func Test_Timeline_Verify_Valid(t *testing.T) {
 	testCases := []struct {
 		obj *metupd.CreateI
 	}{
-		// Case 0 ensures that create input can be considered valid.
+		// Case 0 ensures that create input with only a single datapoint is
+		// valid.
 		{
 			obj: &metupd.CreateI{
-				Datapoint: []int64{
-					1605025038,
+				Yaxis: []int64{
+					32,
+				},
+				Text:     "Lorem ipsum ...",
+				Timeline: "tml-al9qy",
+			},
+		},
+		// Case 1 ensures that create input with multiple datapoints is valid.
+		{
+			obj: &metupd.CreateI{
+				Yaxis: []int64{
+					32,
 					85,
 				},
 				Text:     "Lorem ipsum ...",
 				Timeline: "tml-al9qy",
 			},
 		},
-		// Case 0 ensures that create input can be considered valid.
+		// Case 2 ensures that create input with multiple datapoints is valid.
 		{
 			obj: &metupd.CreateI{
-				Datapoint: []int64{
-					1604959525,
+				Yaxis: []int64{
+					32,
+					556,
+					1,
 					2500,
 				},
 				Text:     "foo bar #hashtag",


### PR DESCRIPTION
With this the apiserver is functional the first time. You can build and run it like this if you have `go` installed. Note that the server does not log anything at this point. 

```
go build && ./apiserver daemon
```

This is how you can run redis given you have `docker` installed. Redis is used as datastore. 

```
docker run --rm -p 127.0.0.1:6379:6379 redis
```

Searching for metrics the first time against the apiserver does not result in any data, since non got created yet. Note you need `grpcurl` installed. 

```
$ grpcurl -plaintext -d '{"filter":{"property":[{"timeline":"tml-al9qy"}]}}' 127.0.0.1:7777 metric.API.Search
{

}
```

Creating the first metric update against the apiserver can be done like this. Right now only the timestamp of creation is returned. 

```
$ grpcurl -plaintext -d '{"yaxis":[5,40],"text":"Lorem ipsum ...","timeline":"tml-al9qy"}' 127.0.0.1:7777 metupd.API.Create
{
  "timestamp": "1605311478"
}
```

Searching for metrics again shows the metric object we just created. 

```
$ grpcurl -plaintext -d '{"filter":{"property":[{"timeline":"tml-al9qy"}]}}' 127.0.0.1:7777 metric.API.Search
{
  "result": [
    {
      "yaxis": [
        "5",
        "40"
      ],
      "timeline": "tml-al9qy",
      "timestamp": "1605311478"
    }
  ]
}
```