### PR TITLE
verify amount of y axis coordinates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/spf13/cobra v1.1.1
 	github.com/venturemark/apigengo v0.0.0-20201113231625-ccfc7cd43d76
 	github.com/xh3b4sd/logger v0.1.2
-	github.com/xh3b4sd/redigo v0.1.0
+	github.com/xh3b4sd/redigo v0.2.0
 	github.com/xh3b4sd/tracer v0.3.1
 	google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/venturemark/apigengo v0.0.0-20201113231625-ccfc7cd43d76 h1:UgIxN8NJQC
 github.com/venturemark/apigengo v0.0.0-20201113231625-ccfc7cd43d76/go.mod h1:1H03FtN0jnnENa+gdfCRwOTrJVG6c8ztI4EWHRGpD4A=
 github.com/xh3b4sd/logger v0.1.2 h1:zEE3obzyrGofvTNbT+T2U654e9XwqmGbzyktdRB1BR8=
 github.com/xh3b4sd/logger v0.1.2/go.mod h1:/mTz2elyBeH3rPq5vEqAJRWYt/6huhY/b3Hrzych2GE=
-github.com/xh3b4sd/redigo v0.1.0 h1:HrvUTKfivYq0FL7iVWlEo9biJ/c6sz30YDeGDWWqt7A=
-github.com/xh3b4sd/redigo v0.1.0/go.mod h1:BILWOYa0jGb1rACFyBQCKdoj9LAkSErq8xyi7sDiaMk=
+github.com/xh3b4sd/redigo v0.2.0 h1:wldR7i3j0wMjOwNK4OYuTI/sog6gfXwhH5sI4vEwoXI=
+github.com/xh3b4sd/redigo v0.2.0/go.mod h1:BILWOYa0jGb1rACFyBQCKdoj9LAkSErq8xyi7sDiaMk=
 github.com/xh3b4sd/tracer v0.3.1 h1:wv4Cy/u/xLXLUJeKQWeiR+aU4mywj2f8PkQVda1EXKQ=
 github.com/xh3b4sd/tracer v0.3.1/go.mod h1:ZOLvBVLrmNx3GLCL7j0vEGMuI3r5ltLFcmDjG/3nV7g=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/handler/metric/search.go
+++ b/pkg/handler/metric/search.go
@@ -11,7 +11,11 @@ func (h *Handler) Search(ctx context.Context, obj *metric.SearchI) (*metric.Sear
 	// Search for any metric associated with the given updates. One or many
 	// update IDs may be provided.
 	{
-		ok := h.storage.Metric.Search.Non.Timeline.Verify(obj)
+		ok, err := h.storage.Metric.Search.Non.Timeline.Verify(obj)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+
 		if ok {
 			res, err := h.storage.Metric.Search.Non.Timeline.Search(obj)
 			if err != nil {

--- a/pkg/handler/metupd/create.go
+++ b/pkg/handler/metupd/create.go
@@ -10,7 +10,11 @@ import (
 func (h *Handler) Create(ctx context.Context, obj *metupd.CreateI) (*metupd.CreateO, error) {
 	// Create metric updates associated with the given timeline.
 	{
-		ok := h.storage.MetUpd.Create.Non.Timeline.Verify(obj)
+		ok, err := h.storage.MetUpd.Create.Non.Timeline.Verify(obj)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+
 		if ok {
 			res, err := h.storage.MetUpd.Create.Non.Timeline.Create(obj)
 			if err != nil {

--- a/pkg/storage/metric/search/non/timeline/verify.go
+++ b/pkg/storage/metric/search/non/timeline/verify.go
@@ -4,12 +4,12 @@ import (
 	"github.com/venturemark/apigengo/pkg/pbf/metric"
 )
 
-func (t *Timeline) Verify(obj *metric.SearchI) bool {
+func (t *Timeline) Verify(obj *metric.SearchI) (bool, error) {
 	{
 		// We need a filter. Any search request without it does not make sense,
 		// because we do then not even know what we should search for.
 		if obj.Filter == nil {
-			return false
+			return false, nil
 		}
 	}
 
@@ -18,7 +18,7 @@ func (t *Timeline) Verify(obj *metric.SearchI) bool {
 		// is not implemented should be prohibited in order to not create the
 		// wrong expectations.
 		if obj.Filter.Chunking != nil {
-			return false
+			return false, nil
 		}
 	}
 
@@ -27,7 +27,7 @@ func (t *Timeline) Verify(obj *metric.SearchI) bool {
 		// implementation. The client tells us exactly what we need to do with
 		// the single timeline ID they provide.
 		if len(obj.Filter.Operator) != 0 {
-			return false
+			return false, nil
 		}
 	}
 
@@ -35,23 +35,23 @@ func (t *Timeline) Verify(obj *metric.SearchI) bool {
 		// Searching using this implementation requires only a single timeline
 		// ID to be given.
 		if len(obj.Filter.Property) != 1 {
-			return false
+			return false, nil
 		}
 
 		for _, p := range obj.Filter.Property {
 			// It is not allowed to provide timestamp properties with the search
 			// request of this particular search implementation.
 			if p.Timestamp != 0 {
-				return false
+				return false, nil
 			}
 			// With this particular search implementation we require only a
 			// single timeline ID to be given. If the timeline ID property is
 			// empty, we decline service for this request.
 			if p.Timeline == "" {
-				return false
+				return false, nil
 			}
 		}
 	}
 
-	return true
+	return true, nil
 }

--- a/pkg/storage/metric/search/non/timeline/verify_test.go
+++ b/pkg/storage/metric/search/non/timeline/verify_test.go
@@ -10,7 +10,7 @@ import (
 	redigofake "github.com/xh3b4sd/redigo/fake"
 )
 
-func Test_Timeline_Verify_Invalid(t *testing.T) {
+func Test_Timeline_Verify_Bool_False(t *testing.T) {
 	testCases := []struct {
 		obj *metric.SearchI
 	}{
@@ -148,7 +148,10 @@ func Test_Timeline_Verify_Invalid(t *testing.T) {
 				}
 			}
 
-			ok := tml.Verify(tc.obj)
+			ok, err := tml.Verify(tc.obj)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if ok != false {
 				t.Fatalf("\n\n%s\n", cmp.Diff(ok, false))
@@ -157,7 +160,7 @@ func Test_Timeline_Verify_Invalid(t *testing.T) {
 	}
 }
 
-func Test_Timeline_Verify_Valid(t *testing.T) {
+func Test_Timeline_Verify_Bool_True(t *testing.T) {
 	testCases := []struct {
 		obj *metric.SearchI
 	}{
@@ -204,7 +207,10 @@ func Test_Timeline_Verify_Valid(t *testing.T) {
 				}
 			}
 
-			ok := tml.Verify(tc.obj)
+			ok, err := tml.Verify(tc.obj)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if ok != true {
 				t.Fatalf("\n\n%s\n", cmp.Diff(ok, true))

--- a/pkg/storage/metupd/create/non/timeline/verify.go
+++ b/pkg/storage/metupd/create/non/timeline/verify.go
@@ -1,15 +1,19 @@
 package timeline
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/venturemark/apigengo/pkg/pbf/metupd"
+	"github.com/xh3b4sd/tracer"
 )
 
-func (t *Timeline) Verify(obj *metupd.CreateI) bool {
+func (t *Timeline) Verify(obj *metupd.CreateI) (bool, error) {
 	{
 		// Creating metric updates requires at least one coordinate on the y
 		// axis. If the client does not provide that we fail.
 		if len(obj.Yaxis) == 0 {
-			return false
+			return false, nil
 		}
 	}
 
@@ -17,24 +21,44 @@ func (t *Timeline) Verify(obj *metupd.CreateI) bool {
 		// Creating metric updates requires some text to be provided. Without
 		// text we cannot allow a metric update to be created.
 		if obj.Text == "" {
-			return false
+			return false, nil
 		}
 
 		// Creating metric updates is limited to text with up to 280 characters.
 		// Nobody should be able to create metric updates with longer text.
 		if len(obj.Text) > 280 {
-			return false
+			return false, nil
 		}
 	}
 
-	{ // nolint: gosimple
+	{
 		// Creating metric updates requires a timeline ID to be provided with
 		// which the metric and the update can be associated with. If the
 		// timeline ID is empty, we decline service for this request.
 		if obj.Timeline == "" {
-			return false
+			return false, nil
 		}
 	}
 
-	return true
+	{
+		k := fmt.Sprintf("tml:%s:met", obj.Timeline)
+
+		s, err := t.redigo.Scored().Search(k, 0, 1)
+		if err != nil {
+			return false, tracer.Mask(err)
+		}
+
+		var c int
+		var y int
+		if len(s) == 1 {
+			c = len(strings.Split(s[0], ",")) - 1
+			y = len(obj.Yaxis)
+		}
+
+		if c != y {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }

--- a/pkg/storage/metupd/create/non/timeline/verify_test.go
+++ b/pkg/storage/metupd/create/non/timeline/verify_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/venturemark/apigengo/pkg/pbf/metupd"
 	loggerfake "github.com/xh3b4sd/logger/fake"
+	"github.com/xh3b4sd/redigo"
 	redigofake "github.com/xh3b4sd/redigo/fake"
 )
 
-func Test_Timeline_Verify_Invalid(t *testing.T) {
+func Test_Timeline_Verify_Bool_False(t *testing.T) {
 	testCases := []struct {
 		obj *metupd.CreateI
 	}{
@@ -58,7 +59,10 @@ func Test_Timeline_Verify_Invalid(t *testing.T) {
 				}
 			}
 
-			ok := tml.Verify(tc.obj)
+			ok, err := tml.Verify(tc.obj)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if ok != false {
 				t.Fatalf("\n\n%s\n", cmp.Diff(ok, false))
@@ -67,7 +71,7 @@ func Test_Timeline_Verify_Invalid(t *testing.T) {
 	}
 }
 
-func Test_Timeline_Verify_Valid(t *testing.T) {
+func Test_Timeline_Verify_Bool_True(t *testing.T) {
 	testCases := []struct {
 		obj *metupd.CreateI
 	}{
@@ -125,10 +129,188 @@ func Test_Timeline_Verify_Valid(t *testing.T) {
 				}
 			}
 
-			ok := tml.Verify(tc.obj)
+			ok, err := tml.Verify(tc.obj)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			if ok != true {
 				t.Fatalf("\n\n%s\n", cmp.Diff(ok, true))
+			}
+		})
+	}
+}
+
+func Test_Timeline_Verify_Search_False(t *testing.T) {
+	testCases := []struct {
+		obj        *metupd.CreateI
+		searchFake func() ([]string, error)
+	}{
+		// Case 0 ensures that create input with too many y axis coordinates is
+		// not valid.
+		{
+			obj: &metupd.CreateI{
+				Yaxis: []int64{
+					32,
+					85,
+				},
+				Text:     "Lorem ipsum ...",
+				Timeline: "tml-al9qy",
+			},
+			searchFake: func() ([]string, error) {
+				return []string{"1,2"}, nil
+			},
+		},
+		// Case 1 ensures that create input with too many y axis coordinates is
+		// not valid.
+		{
+			obj: &metupd.CreateI{
+				Yaxis: []int64{
+					23,
+					93,
+					53,
+					12,
+				},
+				Text:     "Lorem ipsum ...",
+				Timeline: "tml-al9qy",
+			},
+			searchFake: func() ([]string, error) {
+				return []string{"1,2"}, nil
+			},
+		},
+		// Case 2 ensures that create input with too few y axis coordinates is
+		// not valid.
+		{
+			obj: &metupd.CreateI{
+				Yaxis: []int64{
+					32,
+				},
+				Text:     "Lorem ipsum ...",
+				Timeline: "tml-al9qy",
+			},
+			searchFake: func() ([]string, error) {
+				return []string{"1,2,3,4"}, nil
+			},
+		},
+		// Case 3 ensures that create input with too few y axis coordinates is
+		// not valid.
+		{
+			obj: &metupd.CreateI{
+				Yaxis: []int64{
+					32,
+					85,
+				},
+				Text:     "Lorem ipsum ...",
+				Timeline: "tml-al9qy",
+			},
+			searchFake: func() ([]string, error) {
+				return []string{"1,2,3,4"}, nil
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+
+			var tml *Timeline
+			{
+				c := Config{
+					Logger: loggerfake.New(),
+					Redigo: &redigofake.Client{
+						ScoredFake: func() redigo.Scored {
+							return &redigofake.Scored{
+								SearchFake: tc.searchFake,
+							}
+						},
+					},
+				}
+
+				tml, err = New(c)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			ok, err := tml.Verify(tc.obj)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ok != false {
+				t.Fatalf("\n\n%s\n", cmp.Diff(ok, false))
+			}
+		})
+	}
+}
+
+func Test_Timeline_Verify_Search_True(t *testing.T) {
+	testCases := []struct {
+		obj        *metupd.CreateI
+		searchFake func() ([]string, error)
+	}{
+		// Case 0 ensures that create input with the correct amount of y axis
+		// coordinates is valid.
+		{
+			obj: &metupd.CreateI{
+				Yaxis: []int64{
+					32,
+					85,
+				},
+				Text:     "Lorem ipsum ...",
+				Timeline: "tml-al9qy",
+			},
+			searchFake: func() ([]string, error) {
+				return []string{"1,2,3"}, nil
+			},
+		},
+		// Case 1 ensures that create input with the correct amount of y axis
+		// coordinates is valid.
+		{
+			obj: &metupd.CreateI{
+				Yaxis: []int64{
+					100,
+					150,
+				},
+				Text:     "Lorem ipsum ...",
+				Timeline: "tml-al9qy",
+			},
+			searchFake: func() ([]string, error) {
+				return []string{"1,2,3"}, nil
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+
+			var tml *Timeline
+			{
+				c := Config{
+					Logger: loggerfake.New(),
+					Redigo: &redigofake.Client{
+						ScoredFake: func() redigo.Scored {
+							return &redigofake.Scored{
+								SearchFake: tc.searchFake,
+							}
+						},
+					},
+				}
+
+				tml, err = New(c)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			ok, err := tml.Verify(tc.obj)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ok != true {
+				t.Fatalf("\n\n%s\n", cmp.Diff(ok, false))
 			}
 		})
 	}


### PR DESCRIPTION
Once a timeline is established with metrics the amount of datapoints per metric update must stay constant. Otherwise rendering graphs would be harder and confusing, if not questionable. 