### PR TITLE
add timeline handler

### DIFF
--- a/cmd/daemon/runner.go
+++ b/cmd/daemon/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/venturemark/apiserver/pkg/handler"
 	"github.com/venturemark/apiserver/pkg/handler/metric"
 	"github.com/venturemark/apiserver/pkg/handler/metupd"
+	"github.com/venturemark/apiserver/pkg/handler/timeline"
 	"github.com/venturemark/apiserver/pkg/handler/update"
 	"github.com/venturemark/apiserver/pkg/server/grpc"
 	"github.com/venturemark/apiserver/pkg/storage"
@@ -93,6 +94,19 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 		}
 	}
 
+	var timelineHandler *timeline.Handler
+	{
+		c := timeline.HandlerConfig{
+			Logger:  r.logger,
+			Storage: redisStorage,
+		}
+
+		timelineHandler, err = timeline.NewHandler(c)
+		if err != nil {
+			return tracer.Mask(err)
+		}
+	}
+
 	var updateHandler *update.Handler
 	{
 		c := update.HandlerConfig{
@@ -113,6 +127,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Handlers: []handler.Interface{
 				metricHandler,
 				metupdHandler,
+				timelineHandler,
 				updateHandler,
 			},
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/google/go-cmp v0.5.2
 	github.com/spf13/cobra v1.1.1
-	github.com/venturemark/apigengo v0.0.0-20201119170608-45458551719a
+	github.com/venturemark/apigengo v0.0.0-20201124123333-0f2a68156e02
 	github.com/xh3b4sd/logger v0.1.2
 	github.com/xh3b4sd/redigo v0.3.0
 	github.com/xh3b4sd/tracer v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/venturemark/apigengo v0.0.0-20201119170608-45458551719a h1:A/i/mUg//JYOR00ElsfkIWhr+c9ed/wFjuTGvQs1FZI=
-github.com/venturemark/apigengo v0.0.0-20201119170608-45458551719a/go.mod h1:1H03FtN0jnnENa+gdfCRwOTrJVG6c8ztI4EWHRGpD4A=
+github.com/venturemark/apigengo v0.0.0-20201124123333-0f2a68156e02 h1:rhwfrhnAfCS3ICjKXtLAt2mB6A1VBXxGRqAhIm+CnBk=
+github.com/venturemark/apigengo v0.0.0-20201124123333-0f2a68156e02/go.mod h1:1H03FtN0jnnENa+gdfCRwOTrJVG6c8ztI4EWHRGpD4A=
 github.com/xh3b4sd/logger v0.1.2 h1:zEE3obzyrGofvTNbT+T2U654e9XwqmGbzyktdRB1BR8=
 github.com/xh3b4sd/logger v0.1.2/go.mod h1:/mTz2elyBeH3rPq5vEqAJRWYt/6huhY/b3Hrzych2GE=
 github.com/xh3b4sd/redigo v0.3.0 h1:XImkw/zJoDXvyH4B6reUjy40OS8fxZ/gS4X2Gxdgk+s=

--- a/pkg/handler/timeline/attach.go
+++ b/pkg/handler/timeline/attach.go
@@ -1,0 +1,10 @@
+package timeline
+
+import (
+	"github.com/venturemark/apigengo/pkg/pbf/timeline"
+	"google.golang.org/grpc"
+)
+
+func (h *Handler) Attach(g *grpc.Server) {
+	timeline.RegisterAPIServer(g, h)
+}

--- a/pkg/handler/timeline/create.go
+++ b/pkg/handler/timeline/create.go
@@ -1,0 +1,11 @@
+package timeline
+
+import (
+	"context"
+
+	"github.com/venturemark/apigengo/pkg/pbf/timeline"
+)
+
+func (h *Handler) Create(ctx context.Context, obj *timeline.CreateI) (*timeline.CreateO, error) {
+	return &timeline.CreateO{}, nil
+}

--- a/pkg/handler/timeline/delete.go
+++ b/pkg/handler/timeline/delete.go
@@ -1,0 +1,11 @@
+package timeline
+
+import (
+	"context"
+
+	"github.com/venturemark/apigengo/pkg/pbf/timeline"
+)
+
+func (h *Handler) Delete(ctx context.Context, obj *timeline.DeleteI) (*timeline.DeleteO, error) {
+	return &timeline.DeleteO{}, nil
+}

--- a/pkg/handler/timeline/error.go
+++ b/pkg/handler/timeline/error.go
@@ -1,0 +1,24 @@
+package timeline
+
+import (
+	"errors"
+
+	"github.com/xh3b4sd/tracer"
+)
+
+var invalidConfigError = &tracer.Error{
+	Kind: "invalidConfigError",
+}
+
+func IsInvalidConfig(err error) bool {
+	return errors.Is(err, invalidConfigError)
+}
+
+var invalidInputError = &tracer.Error{
+	Kind: "invalidInputError",
+	Desc: "Could not identify the desired operation based on the provided input.",
+}
+
+func IsInvalidInput(err error) bool {
+	return errors.Is(err, invalidInputError)
+}

--- a/pkg/handler/timeline/handler.go
+++ b/pkg/handler/timeline/handler.go
@@ -1,0 +1,37 @@
+package timeline
+
+import (
+	"github.com/venturemark/apigengo/pkg/pbf/timeline"
+	"github.com/xh3b4sd/logger"
+	"github.com/xh3b4sd/tracer"
+
+	"github.com/venturemark/apiserver/pkg/storage"
+)
+
+type HandlerConfig struct {
+	Logger  logger.Interface
+	Storage *storage.Storage
+}
+
+type Handler struct {
+	logger  logger.Interface
+	storage *storage.Storage
+
+	timeline.UnimplementedAPIServer
+}
+
+func NewHandler(config HandlerConfig) (*Handler, error) {
+	if config.Logger == nil {
+		return nil, tracer.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Storage == nil {
+		return nil, tracer.Maskf(invalidConfigError, "%T.Storage must not be empty", config)
+	}
+
+	h := &Handler{
+		logger:  config.Logger,
+		storage: config.Storage,
+	}
+
+	return h, nil
+}

--- a/pkg/handler/timeline/search.go
+++ b/pkg/handler/timeline/search.go
@@ -1,0 +1,30 @@
+package timeline
+
+import (
+	"context"
+
+	"github.com/venturemark/apigengo/pkg/pbf/timeline"
+	"github.com/xh3b4sd/tracer"
+)
+
+func (h *Handler) Search(ctx context.Context, obj *timeline.SearchI) (*timeline.SearchO, error) {
+	// Search for any timeline associated with the given user. One user ID must
+	// be provided.
+	{
+		ok, err := h.storage.Timeline.Search.Non.User.Verify(obj)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+
+		if ok {
+			res, err := h.storage.Timeline.Search.Non.User.Search(obj)
+			if err != nil {
+				return nil, tracer.Mask(err)
+			}
+
+			return res, nil
+		}
+	}
+
+	return nil, tracer.Mask(invalidInputError)
+}

--- a/pkg/handler/timeline/update.go
+++ b/pkg/handler/timeline/update.go
@@ -1,0 +1,11 @@
+package timeline
+
+import (
+	"context"
+
+	"github.com/venturemark/apigengo/pkg/pbf/timeline"
+)
+
+func (h *Handler) Update(ctx context.Context, obj *timeline.UpdateI) (*timeline.UpdateO, error) {
+	return &timeline.UpdateO{}, nil
+}

--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -3,4 +3,5 @@ package key
 const (
 	TimelineMetric = "tml:%s:met"
 	TimelineUpdate = "tml:%s:upd"
+	UserTimeline   = "usr:%s:tml"
 )

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -3,6 +3,7 @@ package metadata
 const (
 	Timeline = "venturemark.co/timeline"
 	Unixtime = "venturemark.co/unixtime"
+	User     = "venturemark.co/user"
 )
 
 const (

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/venturemark/apiserver/pkg/storage/metric"
 	"github.com/venturemark/apiserver/pkg/storage/metupd"
+	"github.com/venturemark/apiserver/pkg/storage/timeline"
 	"github.com/venturemark/apiserver/pkg/storage/update"
 )
 
@@ -16,9 +17,10 @@ type Config struct {
 }
 
 type Storage struct {
-	Metric *metric.Metric
-	MetUpd *metupd.MetUpd
-	Update *update.Update
+	Metric   *metric.Metric
+	MetUpd   *metupd.MetUpd
+	Timeline *timeline.Timeline
+	Update   *update.Update
 }
 
 func New(config Config) (*Storage, error) {
@@ -50,6 +52,19 @@ func New(config Config) (*Storage, error) {
 		}
 	}
 
+	var timelineStorage *timeline.Timeline
+	{
+		c := timeline.Config{
+			Logger: config.Logger,
+			Redigo: config.Redigo,
+		}
+
+		timelineStorage, err = timeline.New(c)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
 	var updateStorage *update.Update
 	{
 		c := update.Config{
@@ -64,9 +79,10 @@ func New(config Config) (*Storage, error) {
 	}
 
 	s := &Storage{
-		Metric: metricStorage,
-		MetUpd: metupdStorage,
-		Update: updateStorage,
+		Metric:   metricStorage,
+		MetUpd:   metupdStorage,
+		Timeline: timelineStorage,
+		Update:   updateStorage,
 	}
 
 	return s, nil

--- a/pkg/storage/timeline/search/non/non.go
+++ b/pkg/storage/timeline/search/non/non.go
@@ -1,0 +1,41 @@
+package non
+
+import (
+	"github.com/xh3b4sd/logger"
+	"github.com/xh3b4sd/redigo"
+	"github.com/xh3b4sd/tracer"
+
+	"github.com/venturemark/apiserver/pkg/storage/timeline/search/non/user"
+)
+
+type Config struct {
+	Logger logger.Interface
+	Redigo redigo.Interface
+}
+
+type Non struct {
+	User *user.User
+}
+
+func New(config Config) (*Non, error) {
+	var err error
+
+	var u *user.User
+	{
+		c := user.Config{
+			Logger: config.Logger,
+			Redigo: config.Redigo,
+		}
+
+		u, err = user.New(c)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	n := &Non{
+		User: u,
+	}
+
+	return n, nil
+}

--- a/pkg/storage/timeline/search/non/user/error.go
+++ b/pkg/storage/timeline/search/non/user/error.go
@@ -1,0 +1,15 @@
+package user
+
+import (
+	"errors"
+
+	"github.com/xh3b4sd/tracer"
+)
+
+var invalidConfigError = &tracer.Error{
+	Kind: "invalidConfigError",
+}
+
+func IsInvalidConfig(err error) bool {
+	return errors.Is(err, invalidConfigError)
+}

--- a/pkg/storage/timeline/search/non/user/search.go
+++ b/pkg/storage/timeline/search/non/user/search.go
@@ -1,0 +1,59 @@
+package user
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/venturemark/apigengo/pkg/pbf/timeline"
+	"github.com/xh3b4sd/tracer"
+
+	"github.com/venturemark/apiserver/pkg/key"
+	"github.com/venturemark/apiserver/pkg/metadata"
+	"github.com/venturemark/apiserver/pkg/value/timeline/element"
+)
+
+// Search provides a filter primitive to lookup timelines associated with a
+// user.
+func (t *User) Search(req *timeline.SearchI) (*timeline.SearchO, error) {
+	var err error
+
+	// With redis we use ZREVRANGE which allows us to search for objects while
+	// having support for chunking.
+	var str []string
+	{
+		k := fmt.Sprintf(key.UserTimeline, req.Obj[0].Metadata[metadata.User])
+		str, err = t.redigo.Scored().Search(k, 0, -1)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	// We store timelines in a sorted set. The elements of the sorted set are
+	// concatenated strings of the unix timestamp of timeline creation and the
+	// timeline name.
+	var res *timeline.SearchO
+	{
+		res = &timeline.SearchO{}
+
+		for _, s := range str {
+			uni, val, err := element.Split(s)
+			if err != nil {
+				return nil, tracer.Mask(err)
+			}
+
+			o := &timeline.SearchO_Obj{
+				Metadata: map[string]string{
+					metadata.Unixtime: strconv.Itoa(int(uni)),
+					metadata.User:     req.Obj[0].Metadata[metadata.User],
+				},
+				Property: &timeline.SearchO_Obj_Property{
+					Name: val,
+				},
+			}
+
+			res.Obj = append(res.Obj, o)
+		}
+	}
+
+	return res, nil
+}

--- a/pkg/storage/timeline/search/non/user/user.go
+++ b/pkg/storage/timeline/search/non/user/user.go
@@ -1,0 +1,54 @@
+package user
+
+import (
+	"github.com/xh3b4sd/logger"
+	"github.com/xh3b4sd/redigo"
+	"github.com/xh3b4sd/tracer"
+
+	"github.com/venturemark/apiserver/pkg/verifier/timeline/search"
+	"github.com/venturemark/apiserver/pkg/verifier/timeline/search/empty"
+)
+
+type Config struct {
+	Logger logger.Interface
+	Redigo redigo.Interface
+}
+
+type User struct {
+	logger logger.Interface
+	redigo redigo.Interface
+
+	verify []search.Interface
+}
+
+func New(config Config) (*User, error) {
+	if config.Logger == nil {
+		return nil, tracer.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Redigo == nil {
+		return nil, tracer.Maskf(invalidConfigError, "%T.Redigo must not be empty", config)
+	}
+
+	var err error
+
+	var emptyVerifier *empty.Verifier
+	{
+		c := empty.VerifierConfig{}
+
+		emptyVerifier, err = empty.NewVerifier(c)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	u := &User{
+		logger: config.Logger,
+		redigo: config.Redigo,
+
+		verify: []search.Interface{
+			emptyVerifier,
+		},
+	}
+
+	return u, nil
+}

--- a/pkg/storage/timeline/search/non/user/verify.go
+++ b/pkg/storage/timeline/search/non/user/verify.go
@@ -1,0 +1,20 @@
+package user
+
+import (
+	"github.com/venturemark/apigengo/pkg/pbf/timeline"
+	"github.com/xh3b4sd/tracer"
+)
+
+func (u *User) Verify(req *timeline.SearchI) (bool, error) {
+	for _, v := range u.verify {
+		ok, err := v.Verify(req)
+		if err != nil {
+			return false, tracer.Mask(err)
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/storage/timeline/search/search.go
+++ b/pkg/storage/timeline/search/search.go
@@ -1,0 +1,41 @@
+package search
+
+import (
+	"github.com/xh3b4sd/logger"
+	"github.com/xh3b4sd/redigo"
+	"github.com/xh3b4sd/tracer"
+
+	"github.com/venturemark/apiserver/pkg/storage/timeline/search/non"
+)
+
+type Config struct {
+	Logger logger.Interface
+	Redigo redigo.Interface
+}
+
+type Search struct {
+	Non *non.Non
+}
+
+func New(config Config) (*Search, error) {
+	var err error
+
+	var n *non.Non
+	{
+		c := non.Config{
+			Logger: config.Logger,
+			Redigo: config.Redigo,
+		}
+
+		n, err = non.New(c)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	s := &Search{
+		Non: n,
+	}
+
+	return s, nil
+}

--- a/pkg/storage/timeline/timeline.go
+++ b/pkg/storage/timeline/timeline.go
@@ -1,0 +1,41 @@
+package timeline
+
+import (
+	"github.com/xh3b4sd/logger"
+	"github.com/xh3b4sd/redigo"
+	"github.com/xh3b4sd/tracer"
+
+	"github.com/venturemark/apiserver/pkg/storage/timeline/search"
+)
+
+type Config struct {
+	Logger logger.Interface
+	Redigo redigo.Interface
+}
+
+type Timeline struct {
+	Search *search.Search
+}
+
+func New(config Config) (*Timeline, error) {
+	var err error
+
+	var s *search.Search
+	{
+		c := search.Config{
+			Logger: config.Logger,
+			Redigo: config.Redigo,
+		}
+
+		s, err = search.New(c)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
+	t := &Timeline{
+		Search: s,
+	}
+
+	return t, nil
+}

--- a/pkg/value/timeline/element/join.go
+++ b/pkg/value/timeline/element/join.go
@@ -1,0 +1,7 @@
+package element
+
+import "fmt"
+
+func Join(uni float64, nam string) string {
+	return fmt.Sprintf("%f,%s", uni, nam)
+}

--- a/pkg/value/timeline/element/split.go
+++ b/pkg/value/timeline/element/split.go
@@ -1,0 +1,29 @@
+package element
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/xh3b4sd/tracer"
+)
+
+func Split(str string) (float64, string, error) {
+	l := strings.Split(str, ",")
+
+	var u float64
+	{
+		i, err := strconv.ParseFloat(l[0], 64)
+		if err != nil {
+			return 0, "", tracer.Mask(err)
+		}
+
+		u = float64(i)
+	}
+
+	var n string
+	{
+		n = l[1]
+	}
+
+	return u, n, nil
+}

--- a/pkg/verifier/timeline/search/empty/error.go
+++ b/pkg/verifier/timeline/search/empty/error.go
@@ -1,0 +1,15 @@
+package empty
+
+import (
+	"errors"
+
+	"github.com/xh3b4sd/tracer"
+)
+
+var invalidConfigError = &tracer.Error{
+	Kind: "invalidConfigError",
+}
+
+func IsInvalidConfig(err error) bool {
+	return errors.Is(err, invalidConfigError)
+}

--- a/pkg/verifier/timeline/search/empty/verifier.go
+++ b/pkg/verifier/timeline/search/empty/verifier.go
@@ -1,0 +1,53 @@
+package empty
+
+import (
+	"github.com/venturemark/apigengo/pkg/pbf/timeline"
+
+	"github.com/venturemark/apiserver/pkg/metadata"
+)
+
+type VerifierConfig struct {
+}
+
+type Verifier struct {
+}
+
+func NewVerifier(config VerifierConfig) (*Verifier, error) {
+	v := &Verifier{}
+
+	return v, nil
+}
+
+// Verify checks if there is any information given for searching timelines. The
+// only piece of information we need is the user ID provided with the object
+// metadata. It is only allowed to provide one search object.
+func (v *Verifier) Verify(req *timeline.SearchI) (bool, error) {
+	{
+		// We need a single object with a single metadata label for the user's
+		// timeline in order to fullfil the search request. We will extend
+		// functionality here later.
+		if len(req.Obj) != 1 {
+			return false, nil
+		}
+		if req.Obj[0].Metadata == nil {
+			return false, nil
+		}
+	}
+
+	{
+		if req.Obj[0].Metadata[metadata.User] == "" {
+			return false, nil
+		}
+	}
+
+	{
+		// Any search request with object property specifics is not valid for
+		// search requests at this point. We will extend functionality here
+		// later.
+		if req.Obj[0].Property != nil {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/pkg/verifier/timeline/search/empty/verifier_test.go
+++ b/pkg/verifier/timeline/search/empty/verifier_test.go
@@ -1,0 +1,170 @@
+package empty
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/venturemark/apigengo/pkg/pbf/timeline"
+
+	"github.com/venturemark/apiserver/pkg/metadata"
+)
+
+func Test_Empty_Verify_False(t *testing.T) {
+	testCases := []struct {
+		req *timeline.SearchI
+	}{
+		// Case 0 ensures that search input without metadata is not valid.
+		{
+			req: &timeline.SearchI{},
+		},
+		// Case 1 ensures that search input without metadata is not valid.
+		{
+			req: &timeline.SearchI{
+				Obj: []*timeline.SearchI_Obj{},
+			},
+		},
+		// Case 2 ensures that search input without metadata is not valid.
+		{
+			req: &timeline.SearchI{
+				Obj: []*timeline.SearchI_Obj{
+					{},
+				},
+			},
+		},
+		// Case 3 ensures that search input without metadata is not valid.
+		{
+			req: &timeline.SearchI{
+				Obj: []*timeline.SearchI_Obj{
+					{
+						Metadata: map[string]string{},
+					},
+				},
+			},
+		},
+		// Case 4 ensures that search input without user ID in the metadata
+		// is not valid.
+		{
+			req: &timeline.SearchI{
+				Obj: []*timeline.SearchI_Obj{
+					{
+						Metadata: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+		},
+		// Case 5 ensures that search input with multiple objects is not valid.
+		{
+			req: &timeline.SearchI{
+				Obj: []*timeline.SearchI_Obj{
+					{
+						Metadata: map[string]string{
+							metadata.User: "usr-al9qy",
+						},
+					},
+					{
+						Metadata: map[string]string{
+							"foo": "bar",
+						},
+					},
+				},
+			},
+		},
+		// Case 6 ensures that search input with object properties is not valid.
+		{
+			req: &timeline.SearchI{
+				Obj: []*timeline.SearchI_Obj{
+					{
+						Metadata: map[string]string{
+							metadata.User: "usr-al9qy",
+						},
+						Property: &timeline.SearchI_Obj_Property{},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+
+			var v *Verifier
+			{
+				c := VerifierConfig{}
+
+				v, err = NewVerifier(c)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			ok, err := v.Verify(tc.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ok != false {
+				t.Fatalf("\n\n%s\n", cmp.Diff(false, ok))
+			}
+		})
+	}
+}
+
+func Test_Empty_Verify_True(t *testing.T) {
+	testCases := []struct {
+		req *timeline.SearchI
+	}{
+		// Case 0 ensures that search input with user ID is valid.
+		{
+			req: &timeline.SearchI{
+				Obj: []*timeline.SearchI_Obj{
+					{
+						Metadata: map[string]string{
+							metadata.User: "usr-al9qy",
+						},
+					},
+				},
+			},
+		},
+		// Case 1 ensures that search input with user ID is valid.
+		{
+			req: &timeline.SearchI{
+				Obj: []*timeline.SearchI_Obj{
+					{
+						Metadata: map[string]string{
+							metadata.User: "usr-kn433",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			var err error
+
+			var v *Verifier
+			{
+				c := VerifierConfig{}
+
+				v, err = NewVerifier(c)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			ok, err := v.Verify(tc.req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if ok != true {
+				t.Fatalf("\n\n%s\n", cmp.Diff(true, ok))
+			}
+		})
+	}
+}

--- a/pkg/verifier/timeline/search/spec.go
+++ b/pkg/verifier/timeline/search/spec.go
@@ -1,0 +1,7 @@
+package search
+
+import "github.com/venturemark/apigengo/pkg/pbf/timeline"
+
+type Interface interface {
+	Verify(req *timeline.SearchI) (bool, error)
+}


### PR DESCRIPTION
This registers the new `timeline` handler. When you run the daemon and list the registered handlers you see the timeline API. 

```
./apiserver daemon
```

```
$ grpcurl -plaintext 127.0.0.1:7777 list
grpc.reflection.v1alpha.ServerReflection
metric.API
metupd.API
timeline.API
update.API
```

Having redis running you can search for timelines. Since timeline creation is the next step to be implemented the result is just empty. 

```
docker run --rm -p 127.0.0.1:6379:6379 redis
```

```
$ grpcurl -d '{"obj":[{"metadata":{"venturemark.co/user":"usr-kn433"}}]}' -plaintext 127.0.0.1:7777 timeline.API.Search
{

}
```