### PR TITLE
fix protocol uppgrade for web clients

### DIFF
--- a/hlm/apiserver/templates/service.yaml
+++ b/hlm/apiserver/templates/service.yaml
@@ -18,5 +18,5 @@ spec:
   selector:
     app.kubernetes.io/name: "{{ .Release.Name }}"
   ports:
-    - name: "grpc"
+    - name: "grpc-web"
       port: {{ .Values.apiserver.port }}


### PR DESCRIPTION
We received 503 errors when starting to integrate the webclient. This here should fix the problem. I guess I messed up synching with [my playground, because there I got it right](https://github.com/xh3b4sd/apiserver/blob/8f9a560692edbfb0b9e223865dbf44179e5f6717/helm/apiserver/templates/service.yaml#L21). With this the network layer problems are solved. Once this is merged, to get the latest changes you need to do two things. 

- Pull the latest changes of your local `sec` copy. 
- Create a new cluster with `kia create knd`. 