### PR TITLE
Return empty result from user search when context user id is empty

### DIFF
--- a/pkg/handler/user/search.go
+++ b/pkg/handler/user/search.go
@@ -29,6 +29,10 @@ func (h *Handler) Search(ctx context.Context, req *user.SearchI) (*user.SearchO,
 			return nil, tracer.Mask(invalidUserError)
 		}
 
+		if usi == "" {
+			return &user.SearchO{}, nil
+		}
+
 		for i := range req.Obj {
 			if req.Obj[i].Metadata[metadata.UserID] == "" {
 				req.Obj[i].Metadata[metadata.UserID] = usi


### PR DESCRIPTION
During authentication, the requesting user ID is added to the context. Any subsequent request that doesn't specify a user ID has it set to the user ID from the context. If the context user ID is the empty string, the function should return an empty result rather than making an invalid request to redis causing an unexpected `index must not be empty` error to be returned.

I'm new to the codebase so let me know if this seems like the right approach.