### PR TITLE
Wire user mail field

### DIFF
--- a/.github/workflows/cfm-test.yaml
+++ b/.github/workflows/cfm-test.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           path: "venturemark/cfm"
           repository: "venturemark/cfm"
+          ref: add-user-mail
 
       - name: "Setup Go Env"
         uses: actions/setup-go@v2
@@ -57,7 +58,7 @@ jobs:
 
       - name: "Install Test Dependency"
         run: |
-          go get -u github.com/venturemark/cfm@$(git ls-remote git://github.com/venturemark/cfm.git add-user-mail | awk '{print $1;}')
+          go get -u github.com/venturemark/cfm@$(git ls-remote git://github.com/venturemark/cfm.git HEAD | awk '{print $1;}')
 
       - name: "Check Conformance Tests"
         env:

--- a/.github/workflows/cfm-test.yaml
+++ b/.github/workflows/cfm-test.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: "Install Test Dependency"
         run: |
-          go get -u github.com/venturemark/cfm@$(git ls-remote git://github.com/venturemark/cfm.git HEAD | awk '{print $1;}')
+          go get -u github.com/venturemark/cfm@$(git ls-remote git://github.com/venturemark/cfm.git add-user-mail | awk '{print $1;}')
 
       - name: "Check Conformance Tests"
         env:

--- a/pkg/storage/user/creator/create.go
+++ b/pkg/storage/user/creator/create.go
@@ -35,6 +35,7 @@ func (c *Creator) Create(req *user.CreateI) (*user.CreateO, error) {
 				Metadata: req.Obj[0].Metadata,
 				Property: schema.UserObjProperty{
 					Desc: req.Obj[0].Property.Desc,
+					Mail: req.Obj[0].Property.Mail,
 					Prof: lin(req.Obj[0].Property.Prof),
 					Name: req.Obj[0].Property.Name,
 				},

--- a/pkg/storage/user/creator/creator.go
+++ b/pkg/storage/user/creator/creator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/venturemark/apiserver/pkg/verifier/user/creator/auth"
 	"github.com/venturemark/apiserver/pkg/verifier/user/creator/empty"
 	"github.com/venturemark/apiserver/pkg/verifier/user/creator/exist"
+	"github.com/venturemark/apiserver/pkg/verifier/user/creator/format"
 	"github.com/venturemark/apiserver/pkg/verifier/user/creator/name"
 )
 
@@ -74,6 +75,16 @@ func New(config Config) (*Creator, error) {
 		}
 	}
 
+	var formatVerifier *format.Verifier
+	{
+		c := format.VerifierConfig{}
+
+		formatVerifier, err = format.NewVerifier(c)
+		if err != nil {
+			return nil, tracer.Mask(err)
+		}
+	}
+
 	var existsVerifier *exist.Verifier
 	{
 		c := exist.VerifierConfig{
@@ -106,6 +117,7 @@ func New(config Config) (*Creator, error) {
 			// The empty verifier must be run first so that following verifiers
 			// do not have to check for prerequisites over and over again.
 			emptyVerifier,
+			formatVerifier,
 			authVerifier,
 			existsVerifier,
 			nameVerifier,

--- a/pkg/storage/user/searcher/search.go
+++ b/pkg/storage/user/searcher/search.go
@@ -49,6 +49,7 @@ func (s *Searcher) Search(req *user.SearchI) (*user.SearchO, error) {
 				Property: &user.SearchO_Obj_Property{
 					Desc: use.Obj.Property.Desc,
 					Name: use.Obj.Property.Name,
+					Mail: use.Obj.Property.Mail,
 					Prof: prof(use.Obj.Property.Prof),
 				},
 			}

--- a/pkg/verifier/user/creator/format/error.go
+++ b/pkg/verifier/user/creator/format/error.go
@@ -1,0 +1,15 @@
+package format
+
+import (
+	"errors"
+
+	"github.com/xh3b4sd/tracer"
+)
+
+var invalidConfigError = &tracer.Error{
+	Kind: "invalidConfigError",
+}
+
+func IsInvalidConfig(err error) bool {
+	return errors.Is(err, invalidConfigError)
+}

--- a/pkg/verifier/user/creator/format/verifier.go
+++ b/pkg/verifier/user/creator/format/verifier.go
@@ -1,8 +1,9 @@
-package empty
+package format
 
 import (
 	"context"
 
+	"github.com/badoux/checkmail"
 	"github.com/venturemark/apigengo/pkg/pbf/user"
 )
 
@@ -20,22 +21,8 @@ func NewVerifier(config VerifierConfig) (*Verifier, error) {
 
 func (v *Verifier) Verify(ctx context.Context, req *user.CreateI) (bool, error) {
 	{
-		if len(req.Obj) != 1 {
-			return false, nil
-		}
-		if req.Obj[0].Property == nil {
-			return false, nil
-		}
-	}
-
-	{
-		if req.Obj[0].Property.Name == "" {
-			return false, nil
-		}
-	}
-
-	{
-		if req.Obj[0].Property.Mail == "" {
+		err := checkmail.ValidateFormat(req.Obj[0].Property.Mail)
+		if err != nil {
 			return false, nil
 		}
 	}

--- a/pkg/verifier/user/updater/patch/verifier.go
+++ b/pkg/verifier/user/updater/patch/verifier.go
@@ -3,6 +3,7 @@ package patch
 import (
 	"context"
 
+	"github.com/badoux/checkmail"
 	"github.com/venturemark/apicommon/pkg/metadata"
 	"github.com/venturemark/apigengo/pkg/pbf/user"
 )
@@ -84,6 +85,26 @@ func (v *Verifier) Verify(ctx context.Context, req *user.UpdateI) (bool, error) 
 			valLen := req.Obj[0].Jsnpatch[i].Val != nil && len(*req.Obj[0].Jsnpatch[i].Val) <= 32
 
 			if !valEmp && !valLen {
+				return false, nil
+			}
+		}
+	}
+
+	{
+		for i := range req.Obj[0].Jsnpatch {
+			if req.Obj[0].Jsnpatch[i].Pat != "/obj/property/mail" {
+				continue
+			}
+
+			valEmp := req.Obj[0].Jsnpatch[i].Val != nil && *req.Obj[0].Jsnpatch[i].Val == ""
+			valLen := req.Obj[0].Jsnpatch[i].Val != nil && len(*req.Obj[0].Jsnpatch[i].Val) <= 320
+
+			if !valEmp && !valLen {
+				return false, nil
+			}
+
+			err := checkmail.ValidateFormat(*req.Obj[0].Jsnpatch[i].Val)
+			if err != nil {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
For email integration roadmap issue.

This PR:

- Saves user email address to the DB on creation and update requests.
- Returns the email address when searching users.
- Adds validation of the email to user creation and update handlers. Email must be between 1 and 320 characters in length and match the email regex.