### PR TITLE
Add okteto (including Apple Silicon support)

### DIFF
--- a/.stignore
+++ b/.stignore
@@ -1,0 +1,3 @@
+.git
+apiserver
+__debug_bin

--- a/okteto.yaml
+++ b/okteto.yaml
@@ -1,0 +1,26 @@
+name: apiserver
+namespace: infra
+selector:
+  app.kubernetes.io/name: apiserver
+image: okteto/golang:1.17
+imagePullPolicy: IfNotPresent
+command:
+  - bash
+  - -c
+  - "dlv debug --headless --listen=:2345 --api-version=2 --accept-multiclient -- daemon --redis-host=rfs-redis-failover.infra.svc.cluster.local --redis-kind=sentinel --redis-port=26379"
+workdir: /okteto
+forward:
+  - 2345:2345
+persistentVolume:
+  enabled: false
+resources:
+  limits:
+    cpu: "2"
+    memory: 2Gi
+securityContext:
+  runAsUser: 0
+  runAsGroup: 1000
+  fsGroup: 1000
+  capabilities:
+    add:
+      - SYS_PTRACE

--- a/okteto/bashrc
+++ b/okteto/bashrc
@@ -1,0 +1,5 @@
+cat << EOF
+Welcome to your development container. Happy coding!
+EOF
+
+export PS1="\[\e[36m\]\${OKTETO_NAMESPACE:-okteto}:\[\e[32m\]\${OKTETO_NAME:-dev} \[\e[m\]\W> "

--- a/okteto/okteto-golang-arm.dockerfile
+++ b/okteto/okteto-golang-arm.dockerfile
@@ -1,0 +1,14 @@
+ARG VERSION=1.17
+FROM golang:$VERSION-buster
+
+WORKDIR /usr/src/app
+
+# setup okteto message
+COPY bashrc /root/.bashrc
+
+RUN go get github.com/codegangsta/gin && \
+    go get -u github.com/go-delve/delve/cmd/dlv && \
+    go get -u golang.org/x/tools/gopls && \
+    curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin
+
+CMD ["bash"]

--- a/okteto/okteto-init.sh
+++ b/okteto/okteto-init.sh
@@ -1,0 +1,2 @@
+docker build -t okteto/golang:1.17 -f okteto-golang-arm.dockerfile .
+kind load docker-image okteto/golang:1.17


### PR DESCRIPTION
Simplifies debugging of the apiserver.

After starting a cluster with `kia create knd`, run `okteto/okteto-init.sh` to build and load the image. Then run `okteto up` to start the go debugger. Finally connect to the remote debugger in the IDE (`localhost:2345`).